### PR TITLE
fixed tile cutting problem in tile_map.py

### DIFF
--- a/tools/cut_training_images/tile_map.py
+++ b/tools/cut_training_images/tile_map.py
@@ -32,6 +32,27 @@ class TileMap:
     def tile_fn_for_tile(self,tile):
         return '{}/tiles/tile-{}_{}.jpg'.format(self.map_dir,tile[0],tile[1])
 
+    def concat_tiles(self, img, tilepixel, move_x, move_y, paste_x, paste_y, lim1, corner=False, lim2=None):
+        """
+        This is a helper function for crop_around_tilepixel to avoid a bunch of if/else statements
+        --- It creates the 8 tiles that neighbour original tile in new 3000x3000 image
+        --- Controls for edge case of tile being on border of full map
+                --- pastes blank image of same size where a neighbouring tile doesnt exists
+        """
+        if not corner:
+            if tilepixel[0][lim1[0]] == lim1[1]:
+                tile = Image.new("RGB", (1000, 1000))
+            else:
+                fn = self.tile_fn_for_tile([tilepixel[0][0] + move_x, tilepixel[0][1] + move_y])
+                tile = Image.open(fn)
+        else:
+            if tilepixel[0][lim1[0]] == lim1[1] or tilepixel[0][lim2[0]] == lim2[1]:
+                tile = Image.new("RGB", (1000, 1000))
+            else:
+                fn = self.tile_fn_for_tile([tilepixel[0][0] + move_x, tilepixel[0][1] + move_y])
+                tile = Image.open(fn)
+        img.paste(tile, (paste_x, paste_y))
+
     def crop_around_tilepixel(self,tilepixel,pixels_wide):
         fn = self.tile_fn_for_tile(tilepixel[0])
         img = Image.open(fn)
@@ -41,8 +62,33 @@ class TileMap:
         lower = [pixel[0]-l2rad, pixel[1]-l2rad]
         upper = [pixel[0]+l2rad, pixel[1]+l2rad]
         # TODO grab pixels from multiple tiles
-        if (lower[0] < 0 or lower[1] < 0 or upper[1] > width or upper[1] > height):
-            raise TileMapBoundsError("out of bounds")
+        if (lower[0] < 0 or lower[1] < 0 or upper[0] > width or upper[1] > height):
+            # add 8 neighbouring tiles to make bigger square (3000x3000)
+            try:
+                # create new blank 3000x3000 image
+                new_img = Image.new("RGB", (3000, 3000))
+                # list of params to pass in helper function, 0th element is tile position
+                to_add = [['top_left', -1, 1, 0, 0, [0,0], True, [1,self.tile_count[1]-1]],
+                          ['mid_left', -1, 0, 0, 1000, [0,0], False, None],
+                          ['bottom_left', -1, -1, 0, 2000, [0,0], True, [1, 0]],
+                          ['top_middle', 0, 1, 1000, 0, [1,self.tile_count[1]-1], False, None],
+                          ['bottom_middle', 0, -1, 1000, 2000, [1,0], False, None],
+                          ['top_right', 1, 1, 2000, 0, [0,self.tile_count[0]-1], True, [1,self.tile_count[1]-1]],
+                          ['middle_right', 1, 0, 2000, 1000, [0,self.tile_count[0]-1], False, None],
+                          ['bottom_right', 1, -1, 2000, 2000, [0,self.tile_count[0]-1], True, [1,0]]]
+                for block in to_add:
+                    self.concat_tiles(new_img, tilepixel, block[1], block[2], block[3],
+                                        block[4], block[5], block[6], block[7])
+                # paste original image in center
+                new_img.paste(img, (1000, 1000))
+                width, height = new_img.size
+                lower = [lower[0]+1000, lower[1]+1000]
+                upper = [upper[0]+1000, upper[1]+1000]
+                img = new_img
+            except:
+                # try/except just for precaution, but error never raised here
+                # always comes from tilepixel_with_stateplane()
+                raise TileMapBoundsError("out of bounds")
         # PIL origin at upper left
         # our origin at lower left
         pil_left  = lower[0]


### PR DESCRIPTION
Used the most simple solution which transforms the 1000x1000 tile where tree is to close to the edge into a 3000x3000 tile where original tile in in the middle and 8 surrounding tiles are its neighbours. Only errors are coming from tilepixel_with_stateplane() function, and I am assuming it's because those coordinates are out of scope of the manhattan map. 
